### PR TITLE
Fix day's generating

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -108,7 +108,8 @@ function generateRewardsConfig(rewardsList, month) {
 
         reward.day = i;
         delete reward.weight;
-        rewardsConfig.push(reward);
+        //Копируем объект в общий массив
+		rewardsConfig.push(Object.assign({}, reward));
     }
 }
 


### PR DESCRIPTION
Объекты привязываются к массиву в который их добавляют. 
Т.е. изменяя reward - оно изменяет уже то, что было добавлено в массив ранее.
По-этому нужно создавать независимую копию объекта reward при добавлении.